### PR TITLE
Refactor classes to plain classes with enums, update Python versions and dependencies

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/examples/add_invoice.py
+++ b/examples/add_invoice.py
@@ -72,12 +72,12 @@ def main():
             update=True,
             country_id=225,
         ),
-        invoice_settings=InvoiceSettings(language=Language.English),
+        invoice_settings=InvoiceSettings(language=Language.ENGLISH),
     )
 
     try:
         with open("invoice.pdf", "wb") as f:
-            invoice.get_pdf(invoice=resp, descriptor=f, language=Language.English)
+            invoice.get_pdf(invoice=resp, descriptor=f, language=Language.ENGLISH)
         print("Invoice saved to 'invoice.pdf'")
     except Exception as e:
         print(f"Error generating or saving invoice as PDF: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests~=2.32.3
-python-dotenv~=1.0.1
-setuptools~=75.8.0
+requests~=2.32.5
+python-dotenv~=1.2.1
+setuptools~=78.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests~=2.32.5
 python-dotenv~=1.2.1
-setuptools~=78.1.1
+setuptools==78.1.1

--- a/superfaktura/bank_account.py
+++ b/superfaktura/bank_account.py
@@ -38,7 +38,7 @@ class NoDefaultBankAccountException(Exception):
 
 
 @dataclass
-class BankAccountModel:
+class BankAccountModel:  # pylint: disable=too-many-instance-attributes
     """Dataclass representing a bank account."""
 
     account: Optional[str]

--- a/superfaktura/bank_account.py
+++ b/superfaktura/bank_account.py
@@ -86,9 +86,6 @@ class BankAccount(SuperFakturaAPI):
         >>> bank.post(data)
     """
 
-    def __init__(self):
-        super().__init__()
-
     def list(self) -> dict:
         """Retrieves a list of bank accounts."""
         url = "bank_accounts/index"

--- a/superfaktura/client_contacts.py
+++ b/superfaktura/client_contacts.py
@@ -89,9 +89,6 @@ class ClientContactModel:  # pylint: disable=too-many-instance-attributes
 class ClientContact(SuperFakturaAPI):
     """Client contact class."""
 
-    def __init__(self):
-        super().__init__()
-
     def add_contact(self, contact: ClientContactModel) -> bool:
         """Adds a new client contact."""
         url = "clients/create"

--- a/superfaktura/client_contacts.py
+++ b/superfaktura/client_contacts.py
@@ -32,7 +32,7 @@ class ClientException(Exception):
 
 
 @dataclasses.dataclass
-class ClientContactModel:
+class ClientContactModel:  # pylint: disable=too-many-instance-attributes
     """Client contact model."""
 
     name: str

--- a/superfaktura/enumerations/currency.py
+++ b/superfaktura/enumerations/currency.py
@@ -12,7 +12,7 @@ Usage:
 """
 
 
-class Currencies:
+class Currencies:  # pylint: disable=too-many-instance-attributes
     """
     Currency Enumeration.
 

--- a/superfaktura/enumerations/currency.py
+++ b/superfaktura/enumerations/currency.py
@@ -11,8 +11,10 @@ Usage:
     currency = Currencies.CZK
 """
 
+from enum import Enum
 
-class Currencies:  # pylint: disable=too-many-instance-attributes
+
+class Currencies(str, Enum):
     """
     Currency Enumeration.
 

--- a/superfaktura/enumerations/language.py
+++ b/superfaktura/enumerations/language.py
@@ -53,3 +53,7 @@ class Language(str, Enum):
     SLOVENE = "slv"
     SPANISH = "spa"
     UKRAINIAN = "ukr"
+
+    def __str__(self) -> str:
+        """Return the string value of the language."""
+        return self.value

--- a/superfaktura/enumerations/language.py
+++ b/superfaktura/enumerations/language.py
@@ -8,47 +8,48 @@ Classes:
 
 Usage:
     from superfaktura.enumerations.language import Language
-    language = Language.Czech
+    language = Language.CZECH
 """
+from enum import Enum
 
 
-class Language:
+class Language(str, Enum):
     """
     Language Enumeration.
 
     This enumeration represents the different languages that can be used in the SuperFaktura API.
 
     Values:
-        - Czech: Czech
-        - German: German
-        - English: English
-        - Croatian: Croatian
-        - Hungarian: Hungarian
-        - Italian: Italian
-        - Dutch: Dutch
-        - Polish: Polish
-        - Romanian: Romanian
-        - Russian: Russian
-        - Slovak: Slovak
-        - Slovene: Slovene
-        - Spanish: Spanish
-        - Ukrainian: Ukrainian
+        - CZECH: Czech
+        - GERMAN: German
+        - ENGLISH: English
+        - CROATIAN: Croatian
+        - HUNGARIAN: Hungarian
+        - ITALIAN: Italian
+        - DUTCH: Dutch
+        - POLISH: Polish
+        - ROMANIAN: Romanian
+        - RUSSIAN: Russian
+        - SLOVAK: Slovak
+        - SLOVENE: Slovene
+        - SPANISH: Spanish
+        - UKRAINIAN: Ukrainian
 
     Usage:
-        language = Language.Czech
+        language = Language.CZECH
     """
 
-    Czech = "cze"
-    German = "deu"
-    English = "eng"
-    Croatian = "hrv"
-    Hungarian = "hun"
-    Italian = "ita"
-    Dutch = "nld"
-    Polish = "pol"
-    Romanian = "rom"
-    Russian = "rus"
-    Slovak = "slo"
-    Slovene = "slv"
-    Spanish = "spa"
-    Ukrainian = "ukr"
+    CZECH = "cze"
+    GERMAN = "deu"
+    ENGLISH = "eng"
+    CROATIAN = "hrv"
+    HUNGARIAN = "hun"
+    ITALIAN = "ita"
+    DUTCH = "nld"
+    POLISH = "pol"
+    ROMANIAN = "rom"
+    RUSSIAN = "rus"
+    SLOVAK = "slo"
+    SLOVENE = "slv"
+    SPANISH = "spa"
+    UKRAINIAN = "ukr"

--- a/superfaktura/invoice.py
+++ b/superfaktura/invoice.py
@@ -106,6 +106,9 @@ class InvoiceModel:  # pylint: disable=too-many-instance-attributes
     def as_dict(self) -> dict:
         """Returns a dictionary representation of the InvoiceModel."""
         data = asdict(self)
+        # Convert InvoiceType enum to its string value if used
+        if isinstance(data.get("type"), InvoiceType):
+            data["type"] = data["type"].value
         for key in list(data.keys()):
             if data[key] is None:
                 del data[key]
@@ -181,6 +184,9 @@ class InvoiceSettings:  # pylint: disable=too-many-instance-attributes
     def as_dict(self) -> dict:
         """Returns a dictionary representation of the InvoiceSettings."""
         data = asdict(self)
+        # Normalize Enum-like fields to their underlying values for JSON
+        if isinstance(data.get("language"), Language):
+            data["language"] = data["language"].value
         for key in list(data.keys()):
             if data[key] is None:
                 del data[key]
@@ -298,5 +304,6 @@ class Invoice(SuperFakturaAPI):
         Returns:
             None
         """
-        url = f"{language.value}/invoices/pdf/{invoice.invoice_id}/token:{invoice.invoice_token}"
+        lang_code = language.value if isinstance(language, Language) else str(language)
+        url = f"{lang_code}/invoices/pdf/{invoice.invoice_id}/token:{invoice.invoice_token}"
         self.download(url, descriptor)

--- a/superfaktura/invoice.py
+++ b/superfaktura/invoice.py
@@ -49,6 +49,7 @@ Usage:
     )
 """
 
+from enum import Enum
 from dataclasses import dataclass, asdict
 from typing import Optional, List, IO
 import json
@@ -186,7 +187,7 @@ class InvoiceSettings:  # pylint: disable=too-many-instance-attributes
         return data
 
 
-class InvoiceType:  # pylint: disable=too-many-instance-attributes
+class InvoiceType(str, Enum):
     """
     Invoice Type Enumeration.
 

--- a/superfaktura/invoice.py
+++ b/superfaktura/invoice.py
@@ -245,9 +245,6 @@ class Invoice(SuperFakturaAPI):
         )
     """
 
-    def __init__(self):
-        super().__init__()
-
     def add(
         self,
         invoice_model: InvoiceModel,

--- a/superfaktura/invoice.py
+++ b/superfaktura/invoice.py
@@ -60,7 +60,7 @@ from superfaktura.utils.data_types import Date, DateEncoder
 
 
 @dataclass
-class InvoiceModel:
+class InvoiceModel:  # pylint: disable=too-many-instance-attributes
     """This dataclass represents an invoice in the SuperFaktura API."""
 
     add_rounding_item: Optional[int] = 0

--- a/superfaktura/invoice.py
+++ b/superfaktura/invoice.py
@@ -168,7 +168,7 @@ class InvoiceSettings:  # pylint: disable=too-many-instance-attributes
     This dataclass represents the settings for an invoice in the SuperFaktura API.
     """
 
-    language: Optional[str] = None
+    language: Optional[Language] = None
     bysquare: Optional[bool] = None
     callback_payment: Optional[str] = None
     online_payment: Optional[bool] = None
@@ -285,7 +285,7 @@ class Invoice(SuperFakturaAPI):
         self,
         invoice: InvoiceRespModel,
         descriptor: IO[bytes],
-        language: str = Language.CZECH,
+        language: Language = Language.CZECH,
     ) -> None:
         """
         Retrieves the PDF of the invoice.
@@ -293,10 +293,10 @@ class Invoice(SuperFakturaAPI):
         Args:
             invoice (InvoiceRespModel): The response model for the invoice.
             descriptor (IO[bytes]): The descriptor to write the PDF data to.
-            language (str): The language for the PDF.
+            language (Language): The language for the PDF.
 
         Returns:
             None
         """
-        url = f"{language}/invoices/pdf/{invoice.invoice_id}/token:{invoice.invoice_token}"
+        url = f"{language.value}/invoices/pdf/{invoice.invoice_id}/token:{invoice.invoice_token}"
         self.download(url, descriptor)

--- a/superfaktura/invoice.py
+++ b/superfaktura/invoice.py
@@ -118,7 +118,7 @@ class InvoiceModel:
 
 
 @dataclass
-class InvoiceItem:
+class InvoiceItem:  # pylint: disable=too-many-instance-attributes
     """This dataclass represents an invoice item in the SuperFaktura API."""
 
     name: str
@@ -162,7 +162,7 @@ class InvoiceRespModel:
 
 
 @dataclass
-class InvoiceSettings:
+class InvoiceSettings:  # pylint: disable=too-many-instance-attributes
     """
     This dataclass represents the settings for an invoice in the SuperFaktura API.
     """
@@ -186,7 +186,7 @@ class InvoiceSettings:
         return data
 
 
-class InvoiceType:
+class InvoiceType:  # pylint: disable=too-many-instance-attributes
     """
     Invoice Type Enumeration.
 
@@ -287,7 +287,7 @@ class Invoice(SuperFakturaAPI):
         self,
         invoice: InvoiceRespModel,
         descriptor: IO[bytes],
-        language: str = Language.Czech,
+        language: str = Language.CZECH,
     ) -> None:
         """
         Retrieves the PDF of the invoice.

--- a/superfaktura/invoice.py
+++ b/superfaktura/invoice.py
@@ -60,6 +60,20 @@ from superfaktura.superfaktura_api import SuperFakturaAPI
 from superfaktura.utils.data_types import Date, DateEncoder
 
 
+class InvoiceType(str, Enum):
+    """
+    Invoice Type Enumeration.
+
+    This enumeration represents the different types of invoices that can be created.
+
+    Usage:
+        invoice_type = InvoiceType.PROFORMA
+    """
+
+    PROFORMA = "proforma"
+    INVOICE = "regular"
+
+
 @dataclass
 class InvoiceModel:  # pylint: disable=too-many-instance-attributes
     """This dataclass represents an invoice in the SuperFaktura API."""
@@ -99,7 +113,7 @@ class InvoiceModel:  # pylint: disable=too-many-instance-attributes
     sequence_id: Optional[int] = None
     specific: Optional[str] = None
     tax_document: Optional[int] = None
-    type: Optional[str] = None
+    type: Optional[InvoiceType | str] = None
     variable: Optional[str] = None
     vat_transfer: Optional[int] = None
 
@@ -171,7 +185,7 @@ class InvoiceSettings:  # pylint: disable=too-many-instance-attributes
     This dataclass represents the settings for an invoice in the SuperFaktura API.
     """
 
-    language: Optional[Language] = None
+    language: Optional[Language | str] = None
     bysquare: Optional[bool] = None
     callback_payment: Optional[str] = None
     online_payment: Optional[bool] = None
@@ -191,20 +205,6 @@ class InvoiceSettings:  # pylint: disable=too-many-instance-attributes
             if data[key] is None:
                 del data[key]
         return data
-
-
-class InvoiceType(str, Enum):
-    """
-    Invoice Type Enumeration.
-
-    This enumeration represents the different types of invoices that can be created.
-
-    Usage:
-        invoice_type = InvoiceType.PROFORMA
-    """
-
-    PROFORMA = "proforma"
-    INVOICE = "regular"
 
 
 class Invoice(SuperFakturaAPI):
@@ -291,7 +291,7 @@ class Invoice(SuperFakturaAPI):
         self,
         invoice: InvoiceRespModel,
         descriptor: IO[bytes],
-        language: Language = Language.CZECH,
+        language: Language | str = Language.CZECH,
     ) -> None:
         """
         Retrieves the PDF of the invoice.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now tests on Python 3.12–3.14
  * Build tooling and dependencies updated (setuptools, requests, python-dotenv)

* **Breaking Changes**
  * Several public types converted to string-backed enums; enum members renamed to uppercase (e.g., ENGLISH)
  * Multiple data classes converted to plain classes and some explicit constructors removed — construction/serialization behavior may differ

* **Other**
  * Examples updated to use new enum names

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->